### PR TITLE
Depend on 'chalk' package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "blessed": "^0.1.81",
     "blessed-contrib": "^4.7.5",
+    "chalk": "^1.1.3",
     "git-standup": "^2.1.8",
     "parrotsay-api": "^0.1.1",
     "scraperjs": "^1.2.0",


### PR DESCRIPTION
I had an error when `core.js` tried to import chalk. Adding it as a dependency fixed the problem.

Here was the error:

```
Error: Cannot find module 'chalk'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/usr/lib/node_modules/tiny-care-terminal/care.js:8:13)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:140:18)
    at node.js:1043:3
```

P.S. Thanks for this, it's really nice!