### PR TITLE
Fix: scraper return same tweets after refresh interval

### DIFF
--- a/twitterbot.js
+++ b/twitterbot.js
@@ -39,7 +39,8 @@ function scrapeTweet(who) {
             }).get();
         })
         .then(function(tweets) {
-          resolve({text:tweets[0], bot: who});
+          var tweetNumber = Math.floor(Math.random() * tweets.length);
+          resolve({text:tweets[tweetNumber], bot: who});
         },function(error) {
           reject('Can\t scrape tweets. Maybe the user is private or doesn\'t exist?');
         });


### PR DESCRIPTION
lets return random tweet from available ones.

![scraper-random](https://cloud.githubusercontent.com/assets/3471415/25123034/a5367c60-2444-11e7-9a51-af504e7fb9f2.gif)
