### PR TITLE
Remove function keyword from standup-helper.sh

### DIFF
--- a/standup-helper.sh
+++ b/standup-helper.sh
@@ -8,7 +8,7 @@ set -e
 progname=$0
 standup=$(npm bin -g)"/git-standup"
 
-function usage () {
+usage () {
    echo "Usage: "
    echo "  $progname [-d days] [-h] repo1 repo2 etc."
    echo "  -d \t - Specify the number of days back to include"


### PR DESCRIPTION
``function`` as far as I can tell is an optional, non-standard keyword in ``bash`` and on some platforms the script fails with a syntax error if the keyword is included (I've personally found this to be the case on my machine running Debian. Which I assume is defaulting to running the script via ``sh`` which doesn't support ``function``)

Simply removing ``function`` appears to fix issue #14 on the machines I've tested this fix on.