### PR TITLE
typo: second -d should be -h in usage()

### DIFF
--- a/standup-helper.sh
+++ b/standup-helper.sh
@@ -12,7 +12,7 @@ usage () {
    echo "Usage: "
    echo "  $progname [-d days] [-h] repo1 repo2 etc."
    echo "  -d \t - Specify the number of days back to include"
-   echo "  -d \t - Display this help screen"
+   echo "  -h \t - Display this help screen"
 }
 
 # get the optional days


### PR DESCRIPTION
Sorry for a commit request with something this small, but it did confuse me a minute or so, so I hope it can save someone else a minute later:
line 15 I think should have been
   echo "  -h \t - Display this help screen"
not
   echo "  -d \t - Display this help screen"