### PR TITLE
Take only first 3 bots from the list

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 var config = {
   // Accounts to read the last tweet from. The first one in the list will be
   // spoken by the party parrot.
-  twitter: (process.env.TTC_BOTS || 'tinycarebot,selfcare_bot,magicrealismbot').split(','),
+  twitter: (process.env.TTC_BOTS || 'tinycarebot,selfcare_bot,magicrealismbot').split(',').slice(0, 3),
 
   // Set this to false if you want to scrape twitter.com instead of using
   // API keys. The tweets may include RTs in this case :(


### PR DESCRIPTION
I've accidentally put more than 3 bots to TTC_BOTS and screen became corrupted with "Unhandled Promise Rejection" messages. This fix is to make sure app works only with 3 accounts.