### PR TITLE
Add pomodoro feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ lists the environment variables that you can copy in your `rc` files:
   - `TTC_APIKEYS` -- set this to false if you don't want to use Twitter API
   keys and want to scrape the tweets instead.
   - `TTC_UPDATE_INTERVAL`, set this to change the update frequency in minutes, default is 20 minutes.
+  - `TTC_POMODORO` -- set this to false if you don't want to use the pomodoro timer
+  - `TCC_POMODORO_TIMER` and `TCC_POMODORO_BREAK` can be use to set up the preferred times for the pomodoro sessions.
 
 #### Set up Twitter API keys
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ lists the environment variables that you can copy in your `rc` files:
   - `TTC_APIKEYS` -- set this to false if you don't want to use Twitter API
   keys and want to scrape the tweets instead.
   - `TTC_UPDATE_INTERVAL`, set this to change the update frequency in minutes, default is 20 minutes.
-  - `TTC_POMODORO` -- set this to false if you don't want to use the pomodoro timer
+  - `TTC_POMODORO` -- set this to true if you want to use the pomodoro timer
   - `TCC_POMODORO_TIMER` and `TCC_POMODORO_BREAK` can be use to set up the preferred times for the pomodoro sessions.
 
 #### Set up Twitter API keys

--- a/care.js
+++ b/care.js
@@ -36,7 +36,7 @@ var weatherBox = grid.set(0, 8, 2, 4, blessed.box, makeScrollBox(' 🌤 '));
 var todayBox = grid.set(0, 0, 6, 6, blessed.box, makeScrollBox(' 📝  Today '));
 var weekBox = grid.set(6, 0, 6, 6, blessed.box, makeScrollBox(' 📝  Week '));
 
-var commits = grid.set(0, 6, 6, 2, contrib.bar, makeGraphBox('Commits'));
+var commits = grid.set(0, 6, 6, 2, contrib.bar, makeGraphBox('Commits', 10));
 var parrotBox = grid.set(6, 6, 6, 6, blessed.box, makeScrollBox(''));
 
 var tweetBoxes = {}
@@ -45,7 +45,7 @@ tweetBoxes[config.twitter[2]] = grid.set(4, 8, 2, 4, blessed.box, makeBox(' 💬
 
 if (pomodoro_is_active) {
   var pomodoroBox = grid.set(6, 10, 2, 2, blessed.box, makeScrollBox(' 🍅 '));
-  var pomodoroStatsBox = grid.set(8, 10, 4, 2, contrib.bar, {label: 'Pomodoros', barWidth: 5, xOffset: 3, maxHeight: 4});
+  var pomodoroStatsBox = grid.set(8, 10, 4, 2, contrib.bar, makeGraphBox('Pomodoros', 4));
 
   var parrotBox = grid.set(6, 6, 6, 4, blessed.box, makeScrollBox(''));
 } else {
@@ -175,11 +175,11 @@ function makeScrollBox(label) {
   return options;
 }
 
-function makeGraphBox(label) {
+function makeGraphBox(label, height) {
   var options = makeBox(label);
   options.barWidth= 5;
   options.xOffset= 4;
-  options.maxHeight= 10;
+  options.maxHeight= height;
   return options;
 }
 

--- a/care.js
+++ b/care.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 var config = require(__dirname + '/config.js');
 var twitterbot = require(__dirname + '/twitterbot.js');
+var pomodorolib = require(__dirname + '/pomodoro.js');
 
 var spawn = require( 'child_process' ).spawn;
 var blessed = require('blessed');
@@ -8,6 +9,8 @@ var contrib = require('blessed-contrib');
 var chalk = require('chalk');
 var parrotSay = require('parrotsay-api');
 var weather = require('weather-js');
+
+var pomodoro_is_active = config.pomodoro.is_active;
 
 var screen = blessed.screen(
     {fullUnicode: true, // emoji or bust
@@ -32,12 +35,22 @@ var grid = new contrib.grid({rows: 12, cols: 12, screen: screen});
 var weatherBox = grid.set(0, 8, 2, 4, blessed.box, makeScrollBox(' 🌤 '));
 var todayBox = grid.set(0, 0, 6, 6, blessed.box, makeScrollBox(' 📝  Today '));
 var weekBox = grid.set(6, 0, 6, 6, blessed.box, makeScrollBox(' 📝  Week '));
+
 var commits = grid.set(0, 6, 6, 2, contrib.bar, makeGraphBox('Commits'));
 var parrotBox = grid.set(6, 6, 6, 6, blessed.box, makeScrollBox(''));
 
 var tweetBoxes = {}
 tweetBoxes[config.twitter[1]] = grid.set(2, 8, 2, 4, blessed.box, makeBox(' 💖 '));
 tweetBoxes[config.twitter[2]] = grid.set(4, 8, 2, 4, blessed.box, makeBox(' 💬 '));
+
+if (pomodoro_is_active) {
+  var pomodoroBox = grid.set(6, 10, 2, 2, blessed.box, makeScrollBox(' 🍅 '));
+  var pomodoroStatsBox = grid.set(8, 10, 4, 2, contrib.bar, {label: 'Pomodoros', barWidth: 5, xOffset: 3, maxHeight: 4});
+
+  var parrotBox = grid.set(6, 6, 6, 4, blessed.box, makeScrollBox(''));
+} else {
+  var parrotBox = grid.set(6, 6, 6, 6, blessed.box, makeScrollBox(''));
+}
 
 tick();
 setInterval(tick, 1000 * 60 * config.updateInterval);
@@ -46,6 +59,19 @@ function tick() {
   doTheWeather();
   doTheTweets();
   doTheCodes();
+}
+
+if (pomodoro_is_active) {
+  pomodoro = pomodorolib.init(pomodoroBox, screen, pomodoroStatsBox);
+
+  // Start and stop pomodoro on s
+  screen.key(['s'], function(ch, key) {
+    if (pomodoro.isRunning()) {
+      pomodoro.stop();
+    } else {
+      pomodoro.start();
+    }
+  });
 }
 
 function doTheWeather() {

--- a/config.js
+++ b/config.js
@@ -19,6 +19,13 @@ var config = {
 
   updateInterval: parseFloat(process.env.TTC_UPDATE_INTERVAL) || 20,
 
+  // Set to false if you don't want to use Pomodoro
+  pomodoro: {
+    is_active: (process.env.TTC_POMODORO || 'true') === 'true',
+    default_focus_time: process.env.TCC_POMODORO_TIMER || '25:00',
+    default_break_time: process.env.TCC_POMODORO_BREAK || '5:00'
+  },
+
   keys: {
     consumer_key:        process.env.TTC_CONSUMER_KEY || process.env.CONSUMER_KEY || 'none',
     consumer_secret:     process.env.TTC_CONSUMER_SECRET || process.env.CONSUMER_SECRET || 'none',

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "blessed": "^0.1.81",
     "blessed-contrib": "^4.7.5",
     "chalk": "^1.1.3",
-
+    "node-notifier": "^5.1.2",
     "parrotsay-api": "^0.1.1",
+    "piggy-bank": "^1.0.0",
     "scraperjs": "^1.2.0",
+    "timrjs": "^1.0.1",
     "twit": "^2.2.5",
     "weather-js": "^2.0.0"
   },

--- a/pomodoro.js
+++ b/pomodoro.js
@@ -1,0 +1,112 @@
+const config = require(__dirname + '/config.js');
+const path = require('path');
+const Timr = require('timrjs');
+const notifier = require('node-notifier');
+const store = require('piggy-bank')(
+  path.join(require('os').homedir(), '.tinycarepomodoro.json')
+);
+
+function init(box, screen, statsBox) {
+  const default_focus_time = config.pomodoro.default_focus_time;
+  const default_break_time = config.pomodoro.default_break_time;
+  let timer;
+
+  box.content = defaultMsg();
+  refreshPomodoroStats();
+
+  function start() {
+    timer = Timr(default_focus_time);
+    timer.start();
+    updateTimer('⏰', timer, 'Focus Session');
+
+    timer.finish(function() {
+      notifier.notify({
+        title: '🍅  Pomodoro Timer',
+        message: 'Take a break!',
+        sound: true
+      });
+
+      timer = Timr(default_break_time);
+      timer.start();
+      updateTimer('☕️', timer, 'Take a Break');
+
+      incrementTodaysCount();
+
+      timer.finish(function() {
+        notifier.notify({
+          title: '🍅  Pomodoro Timer',
+          message: 'Break is over. Ready for another session?',
+          sound: true
+        });
+        box.content = defaultMsg();
+        screen.render();
+      });
+    });
+  }
+
+  function updateTimer(emoji, timer, msg) {
+    timer.ticker(function({formattedTime}) {
+      box.content = ` ${emoji}  ${formattedTime} - ${msg}`;
+      screen.render();
+    });
+  }
+
+  function incrementTodaysCount() {
+    const today = getToday();
+    store.set(today, (store.get(today) || 0) + 1, {overwrite: true});
+    refreshPomodoroStats();
+  }
+
+  function refreshPomodoroStats() {
+    const today = getToday();
+    statsBox.setData({
+      titles: ['today', 'week'],
+      data: [store.get(today), getWeekPomodoros()]
+    });
+    screen.render();
+  }
+
+  function getToday() {
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  function getWeekPomodoros() {
+    let weekPomodoros = 0;
+    for (let i = 0; i < 7; i++) {
+      let day = new Date();
+      day.setDate(day.getDate()-i);
+      let count = store.get(day.toISOString().slice(0, 10)) || 0;
+      weekPomodoros += count;
+    }
+    return weekPomodoros;
+  }
+
+  function defaultMsg() {
+    const today = getToday();
+    let default_msg = 'Press s to start and stop a session.'
+    if (store.get(today) > 0) {
+      default_msg += `\nYou have completed ${store.get(today)} pomodoros today. Hooray!`
+    }
+    return default_msg;
+  }
+
+  function isRunning() {
+    return timer && timer.isRunning();
+  }
+
+  function stop() {
+    if (timer) {
+      timer.stop();
+      box.content = ` ⏰  Session stopped. \n${defaultMsg()}`;
+      screen.render();
+    }
+  }
+
+  return {
+    start: start,
+    isRunning: isRunning,
+    stop: stop
+  }
+}
+
+module.exports.init = init;

--- a/pomodoro.js
+++ b/pomodoro.js
@@ -61,7 +61,7 @@ function init(box, screen, statsBox) {
     const today = getToday();
     statsBox.setData({
       titles: ['today', 'week'],
-      data: [store.get(today), getWeekPomodoros()]
+      data: [store.get(today) || 0, getWeekPomodoros()]
     });
     screen.render();
   }

--- a/sample.env
+++ b/sample.env
@@ -34,3 +34,10 @@ export CONSUMER_KEY='...'
 export CONSUMER_SECRET='...'
 export ACCESS_TOKEN='...'
 export ACCESS_TOKEN_SECRET='...'
+
+# Set this to false, if you don't use Pomodoros
+export TTC_POMODORO=true
+
+# Configure your preferred pomodoro times
+export TCC_POMODORO_TIMER='25:00'
+export TCC_POMODORO_BREAK='5:00'

--- a/sample.env
+++ b/sample.env
@@ -35,8 +35,8 @@ export CONSUMER_SECRET='...'
 export ACCESS_TOKEN='...'
 export ACCESS_TOKEN_SECRET='...'
 
-# Set this to false, if you don't use Pomodoros
-export TTC_POMODORO=true
+# Set this to true, if you want to use Pomodoros
+export TTC_POMODORO=false
 
 # Configure your preferred pomodoro times
 export TCC_POMODORO_TIMER='25:00'


### PR DESCRIPTION
Hi! I liked your project and since I do big commits instead of small ones, I will rarely see a big list of commits and it will make me feel like I'm not doing anything... 😁

I usually look at my work time by how many pomodoros I've completed throughout the day, so I though it would also be great to have them in the tiny-care-terminal, where I could also see my stats.

I made it configurable so it can be disabled if not used. The length for the focus and break timers are also configurable.

I'm not sure where it could be visually added, so I just made a small room for it next to the parrot. 

I also used some ES6 styles, since I saw you have a PR for reformatting to it.

What do you think?

<img width="954" alt="screen shot 2017-04-23 at 16 37 20" src="https://cloud.githubusercontent.com/assets/493752/25315121/01c2c478-2848-11e7-80a9-d864d37df6cc.png">