### PR TITLE
Change repo name in repos box

### DIFF
--- a/care.js
+++ b/care.js
@@ -173,8 +173,10 @@ function colorizeLog(text) {
   var regex = /(.......) (- .*) (\(.*\)) (<.*>)/i;
   for (var i = 0; i < lines.length; i++) {
     // If it's a path
-    if (lines[i][0] === '/' || lines[i][0] === '\\') {
-      lines[i] = '\n' + chalk.red(lines[i]);
+    if (lines[i][0] === '/') {
+      lines[i] = formatRepoName(lines[i], '/')
+    } else if(lines[i][0] === '\\') {
+      lines[i] = formatRepoName(lines[i], '\\')
     } else {
       // It's a commit.
       var matches = lines[i].match(regex);
@@ -185,4 +187,9 @@ function colorizeLog(text) {
     }
   }
   return lines.join('\n');
+}
+
+function formatRepoName(line, divider) {
+  var path = line.split(divider);
+  return '\n' + chalk.yellow(path[path.length - 1]);
 }


### PR DESCRIPTION
- Show repo's directory name instead of full path

- Use yellow color for the repo name, instead of red, to be different from the color of the commit hash. (I am not so good with colors, If you don't wanna it be yellow tell me 😄 )

**Before**

![image](https://cloud.githubusercontent.com/assets/4822685/25360182/5f503cd2-2948-11e7-853e-7c7d5bd5ca47.png)

**After**

![image](https://cloud.githubusercontent.com/assets/4822685/25360259/b20ffe94-2948-11e7-976e-5074445f075c.png)
