### PR TITLE
Bugfix: don't show repos that have only "administrative" commits

### DIFF
--- a/gitbot.js
+++ b/gitbot.js
@@ -63,15 +63,21 @@ function getCommitsFromRepos(repos, days, callback) {
         if (err)
           return callback(err, null);
 
-        // Repo path
-        if (logs.length >= 1)
-          cmts.push(repo);
-
-        // Commit
+        // Find user commits
+        let commits = [];
         logs.forEach(c => {
+          // filter simple merge commits
           if (c.status && c.status.length)
-            cmts.push(`${c.abbrevHash} - ${c.subject} (${c.authorDateRel}) <${c.authorName.replace('@end@\n','')}>`);
+            commits.push(`${c.abbrevHash} - ${c.subject} (${c.authorDateRel}) <${c.authorName.replace('@end@\n','')}>`);
         });
+
+        // Add repo name and commits
+        if (commits.length >= 1) {
+          // Repo name
+          cmts.push(repo);
+          cmts.push(...commits);
+        }
+
         repoDone();
       });
     } catch(err) {


### PR DESCRIPTION
Small improvement for the gitlog implementation.
At the moment repo names are displayed even if no "real" commits exist. "Real Commits" are user commits with a status, so e.g. no simple merge-commits. 
**This is the expected (git-standup) behavior.**