### PR TITLE
Better repo error handling when using gitlog

### DIFF
--- a/gitbot.js
+++ b/gitbot.js
@@ -61,7 +61,7 @@ function getCommitsFromRepos(repos, days, callback) {
       }, (err, logs) => {
         // Error
         if (err)
-          return callback(err, null);
+          return callback(`Oh Noes😱\nThe repo ${repo} has failed:\n${err}`, null);
 
         // Repo path
         if (logs.length >= 1)


### PR DESCRIPTION
**Before:**
<img width="705" alt="screen shot 2017-05-27 at 11 46 12 pm" src="https://cloud.githubusercontent.com/assets/2384068/26524291/ecc1431a-4336-11e7-8886-8c47f46f5688.png">
**After:**
<img width="704" alt="screen shot 2017-05-27 at 11 45 40 pm" src="https://cloud.githubusercontent.com/assets/2384068/26524292/eceb6b36-4336-11e7-9136-37644bf3a456.png">

Thanks for taking care of us :)