### PR TITLE
Enabled the gitlog option to display commits from all branches

### DIFF
--- a/gitbot.js
+++ b/gitbot.js
@@ -57,7 +57,8 @@ function getCommitsFromRepos(repos, days, callback) {
         number: 100, //max commit count
         since: `${days} days ago`,
         fields: ['abbrevHash', 'subject', 'authorDateRel', 'authorName'],
-        author: gitUsername
+        author: gitUsername,
+        all: true
       }, (err, logs) => {
         // Error
         if (err) {


### PR DESCRIPTION
Hey Monica!

Super cool dashboard. I use it for my standups, for those mornings where the day before is a huge blur.

However, it seems to only list commits for the current branch of my repos - which means that if I have work on multiple branches, I can't get a snapshot of everything I did yesterday.

Luckily, gitlog has an option for that! So I turned it on. Was there a reason why it wasn't on in the first place?

Cheers!