### PR TITLE
Add ability to toggle the commits graph via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,25 +45,25 @@ variables have been set correctly, you can print them in the terminal -- for exa
 
 All the settings the dashboard looks at are in the sample file `sample.env`. This file isn't used by the dashboard, it just
 lists the environment variables that you can copy in your `rc` files:
-  - `TTC_BOTS` are the 3 twitter bots to check, comma separated. The first entry
+  - `TTC_BOTS` -- the 3 twitter bots to check, comma separated. The first entry
   in this list will be displayed in the big party parrot box.
-  - `TTC_SAY_BOX = parrot | bunny | llama | cat | yeoman | mario | ironman | minions | panda`, to party with a different parrot (or,
+  - `TTC_SAY_BOX = parrot | bunny | llama | cat | yeoman | mario | ironman | minions | panda` -- to party with a different parrot (or,
     more specifically: to have a different animal say a message in the big box). You can create your own custom art(.ansi file) [here](https://gauravchl.github.io/ansi-art/webapp/) and download and supply it's absolute path to render it within box. (eg: `TTC_SAY_BOX='/Users/om/desktop/cat.ansi'`)
-  - `TTC_REPOS`, a comma separated list of repos to look at for `git` commits.
-  - `TTC_REPOS_DEPTH` is the max directory-depth to look for git repositories in
+  - `TTC_REPOS` -- a comma separated list of repos to look at for `git` commits.
+  - `TTC_REPOS_DEPTH` -- the max directory-depth to look for git repositories in
   the directories defined with `TTC_REPOS` (by default 1). Note that the deeper
   the directory depth, the slower the results will be fetched.
-  - `TTC_GITBOT` -- how to read your git commits. If you're having problems
-  seeing your commits in `tiny-terminal-care`, set this to `gitlog`
-  - `TTC_WEATHER`, the location to check the weather for. A zipcode doesn't
+  - `TTC_WEATHER` -- the location to check the weather for. A zipcode doesn't
     always work, so if you can, use a location first (so prefer `Paris` over
     `90210`)
-  - `TTC_CELSIUS` (by default true)
+  - `TTC_CELSIUS` -- celsius vs. fahrenheit (true by default)
   - `TTC_APIKEYS` -- set this to false if you don't want to use Twitter API
   keys and want to scrape the tweets instead.
   - `TTC_UPDATE_INTERVAL`, set this to change the update frequency in minutes, default is 20 minutes.
-  - `TTC_TERMINAL_TITLE` -- set this to false if you don't want the terminal title
-  to be changed on startup.
+  - `TTC_GITBOT` -- how to read your git commits. If you're having problems
+  seeing your commits in `tiny-terminal-care`, set this to `gitlog`
+  - `TTC_TERMINAL_TITLE` -- set this to false if you don't want the terminal title to be changed on startup.
+  - `TTC_COMMITS_GRAPH` -- show/hide the commits graph (true by default). Will render number of commits in the labels of the today and week boxes when hidden.
 
 #### Set up Twitter API keys
 

--- a/config.js
+++ b/config.js
@@ -26,6 +26,9 @@ var config = {
   // Set to false if you're an imperial savage. <3
   celsius: (process.env.TTC_CELSIUS || 'true') === 'true',
 
+  // Show/hide the commits graph
+  commitsGraph: (process.env.TTC_COMMITS_GRAPH || 'true') === 'true',
+
   terminal_title: (process.env.TTC_TERMINAL_TITLE === 'false' ? null : '✨💖 tiny care terminal 💖✨'),
 
   updateInterval: parseFloat(process.env.TTC_UPDATE_INTERVAL) || 20,

--- a/sample.env
+++ b/sample.env
@@ -33,6 +33,9 @@ export TTC_APIKEYS=true
 # Refresh the dashboard every 20 minutes.
 export TTC_UPDATE_INTERVAL=20
 
+# Show/hide the commits graph
+export TTC_COMMITS_GRAPH=true
+
 # Turn off terminal title
 export TTC_TERMINAL_TITLE=false
 


### PR DESCRIPTION
Hey @notwaldorf! Thanks for taking the time to build and open source this awesome tool! I love it.

I tend to keep my terminal split into multiple panes, and I noticed the commits graph seems to have rendering issues when in smaller viewports, so I thought it would be helpful if I could easily hide it via environment variables (sort of aligns with #109). I do still like having the total number of commits easily visible for a given day and week, so I added them to the Today and Week box labels when the commits graph is hidden. Here's a quick look:

*Before*
![screen shot 2017-06-25 at 11 30 51 am](https://user-images.githubusercontent.com/1548189/27518672-365e87d4-599a-11e7-9681-ce3bb9878158.jpg)

![screen shot 2017-06-25 at 11 45 27 am](https://user-images.githubusercontent.com/1548189/27518748-cbca0a90-599b-11e7-89c8-0708f6b874fc.jpg)


*After*
![screen shot 2017-06-25 at 11 32 46 am](https://user-images.githubusercontent.com/1548189/27518674-3cefa452-599a-11e7-9151-92ca4bab0585.jpg)

![screen shot 2017-06-25 at 11 44 48 am](https://user-images.githubusercontent.com/1548189/27518749-d06d39c8-599b-11e7-967e-8625c60dd475.jpg)


The PR itself mostly just consists of introducing the new config value and adjusting the size of the boxes accordingly, as well as adding the total number of commits to the box labels.

Let me know what you think!
