### PR TITLE
Default pomodoro variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Other commands while in pomodoro mode:
 
 ```
 
-To change default pomodoro and break durations set following variables (these should be numbers):
+To change default pomodoro and break durations set following variables in minutes (these should be numbers):
 
 ```
 TTC_POMODORO=...

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ Other commands while in pomodoro mode:
 
 ```
 
+To change default pomodoro and break durations set following variables (these should be numbers):
+
+```
+TTC_POMODORO=...
+TTC_BREAK=...
+```
+
 
 ## 🆘 Halp I don't see my commits
 As of version `1.2.0`, there's a new way to

--- a/care.js
+++ b/care.js
@@ -369,9 +369,9 @@ var pomodoroHandlers = {
     }
   },
 
-  runningDuration: parseInt(config.runningDuration),
+  runningDuration: parseInt(config.runningDuration, 10),
 
-  breakDuration: parseInt(config.breakDuration),
+  breakDuration: parseInt(config.breakDuration, 10),
 }
 
 var pomodoroObject = pomodoro(pomodoroHandlers);

--- a/care.js
+++ b/care.js
@@ -368,6 +368,10 @@ var pomodoroHandlers = {
       });
     }
   },
+
+  runningDuration: parseInt(config.runningDuration),
+
+  breakDuration: parseInt(config.breakDuration),
 }
 
 var pomodoroObject = pomodoro(pomodoroHandlers);

--- a/config.js
+++ b/config.js
@@ -35,7 +35,12 @@ var config = {
     consumer_secret:     process.env.TTC_CONSUMER_SECRET || process.env.CONSUMER_SECRET || 'none',
     access_token:        process.env.TTC_ACCESS_TOKEN || process.env.ACCESS_TOKEN || 'none',
     access_token_secret: process.env.TTC_ACCESS_TOKEN_SECRET || process.env.ACCESS_TOKEN_SECRET || 'none',
-  }
+  },
+
+  // Pomodoro Settings
+  runningDuration: process.env.TTC_POMODORO || 20,
+  breakDuration: process.env.TTC_BREAK || 5,
+
 };
 
 module.exports = config;

--- a/pomodoro.js
+++ b/pomodoro.js
@@ -13,8 +13,8 @@ var States = {
 // options.onBreakEnds (function) - Runs when break ends
 var pomodoro = function(options) {
   var _setIntervalId = null;
-  var _runningDuration = 20; // Default pomodoro duration: 20 Min
-  var _breakDuration = 5;    // Default break duration: 5 Min
+  var _runningDuration = options.runningDuration; // Default pomodoro duration: 20 Min
+  var _breakDuration = options.breakDuration;    // Default break duration: 5 Min
   var _runningDurationRemaining = 0; // In seconds
   var _breakDurationRemaining = 0;   // In seconds
   var _currentState = States.STOPPED;

--- a/sample.env
+++ b/sample.env
@@ -50,3 +50,8 @@ export CONSUMER_KEY='...'
 export CONSUMER_SECRET='...'
 export ACCESS_TOKEN='...'
 export ACCESS_TOKEN_SECRET='...'
+
+# Default pomodoro is 20 minutes and default break is 5 minutes.
+# You can change these defaults like this.
+export TTC_POMODORO=25
+export TTC_BREAK=10


### PR DESCRIPTION
implements #116 

Simple addition of variables to `config` file, later they are passed as pomodoro options. I also added short description to README.md. Feel free to add to this.