### PR TITLE
Escape shell args

### DIFF
--- a/care.js
+++ b/care.js
@@ -7,6 +7,7 @@ var ansiArt = require('ansi-art').default;
 
 var notifier = require('node-notifier');
 var spawn = require('child_process').spawn;
+var shellescape = require('shell-escape');
 var blessed = require('blessed');
 var contrib = require('blessed-contrib');
 var chalk = require('chalk');
@@ -165,7 +166,7 @@ function doTheCodes() {
   }
 
   if (config.gitbot.toLowerCase() === 'gitstandup') {
-    var today = spawn('sh ' + __dirname + '/standup-helper.sh', ['-m ' + config.depth, config.repos], {shell:true});
+    var today = spawn('sh', [shellescape([ __dirname + '/standup-helper.sh', '-m', config.depth].concat(config.repos))], {shell:true});
     todayBox.content = '';
     today.stdout.on('data', data => {
       todayCommits = getCommits(`${data}`, todayBox);
@@ -173,7 +174,7 @@ function doTheCodes() {
       screen.render();
     });
 
-    var week = spawn('sh ' + __dirname + '/standup-helper.sh', ['-m ' + config.depth + ' -d 7', config.repos], {shell:true});
+    var week = spawn('sh', [shellescape([ __dirname + '/standup-helper.sh', '-m', config.depth, '-d', '7'].concat(config.repos))], {shell:true});
     weekBox.content = '';
     week.stdout.on('data', data => {
       weekCommits = getCommits(`${data}`, weekBox);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "node-notifier": "^5.1.2",
     "resolve-dir": "^1.0.0",
     "scraperjs": "^1.2.0",
+    "shell-escape": "^0.2.0",
     "sign-bunny": "^1.0.0",
     "subdirs": "^1.0.1",
     "twit": "^2.2.5",

--- a/standup-helper.sh
+++ b/standup-helper.sh
@@ -5,8 +5,8 @@ set -e
 # and run git-standup there directly from node (cwd did nothing), so
 # here we are.
 
-progname=$0
-standup=$(npm bin -g)"/git-standup"
+progname="$0"
+standup="$(npm bin -g)/git-standup"
 
 usage () {
    echo "Usage: "
@@ -20,9 +20,9 @@ usage () {
 days=1
 depth=1
 while getopts "d:m:h" opt; do
-   case $opt in
-   d ) days=$OPTARG;;
-   m ) depth=$OPTARG;;
+   case "$opt" in
+   d ) days="$OPTARG";;
+   m ) depth="$OPTARG";;
    h )  usage ;;
    \?)  usage ;;
    esac
@@ -32,5 +32,5 @@ shift $(($OPTIND - 1))
 # the repo names
 for dir in "$@"
 do
-  (cd $dir; $standup -d $days -m $depth)
+  (cd "$dir"; "$standup" -d "$days" -m "$depth")
 done


### PR DESCRIPTION
Fixes #17 

This should now allow Git paths to include spaces, quotes, etc.