### PR TITLE
fix: forced lowerCase transform on ansi file path

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,7 +4,9 @@ var config = {
   twitter: (process.env.TTC_BOTS || 'tinycarebot,selfcare_bot,magicrealismbot').toLowerCase().split(','),
 
   // Use this to have a different animal say a message in the big box.
-  say: (process.env.TTC_SAY_BOX || 'parrot').toLowerCase(),
+  // regex: if TTC_SAY_BOX is a filePath, return that path
+  say: /(\w[~\/])/.test(process.env.TTC_SAY_BOX)
+    ? process.env.TTC_SAY_BOX : (process.env.TTC_SAY_BOX || 'parrot').toLowerCase(),
 
   // Set this to false if you want to scrape twitter.com instead of using
   // API keys. The tweets may include RTs in this case :(


### PR DESCRIPTION
When adding a custom file path to (.profile | .bash_rc), the previous JS
code forced a lowerCase transformation on the string stored in TTC_SAY_BOX:

`say: (process.env.TTC_SAY_BOX || 'parrot').toLowerCase()`

If the string is a path to custom ansi art, and the user follows a capitalized
directory convention on their system, the transformed file path would be wrong - resulting
in an error ( Art file not found! <path-to-file> ) within the tiny-care-terminal.

![screenshot from 2017-09-23 04-18-47](https://user-images.githubusercontent.com/11083531/30771462-5f1844b8-a016-11e7-9fcf-855069d3fe0a.png)

**The fix**: add a simple regex to check whether or not the string stored
in the TTC_SAY_BOX env var is indeed a file path. If it is, then return that string;
if it is not a file path, then proceed to transform the string:

    say: /(\w[~\/])/.test(process.env.TTC_SAY_BOX)
        ? process.env.TTC_SAY_BOX : (process.env.TTC_SAY_BOX || 'parrot').toLowerCase()

**Tested on**: Linux Elementary OS 0.4.1 Loki