### PR TITLE
Add more details to repo name

### DIFF
--- a/care.js
+++ b/care.js
@@ -5,6 +5,7 @@ var gitbot = require(__dirname + '/gitbot.js');
 var pomodoro = require(__dirname + '/pomodoro.js');
 var ansiArt = require('ansi-art').default;
 
+var path = require('path');
 var notifier = require('node-notifier');
 var spawn = require('child_process').spawn;
 var blessed = require('blessed');
@@ -280,8 +281,14 @@ function colorizeLog(text) {
 }
 
 function formatRepoName(line, divider) {
-  var path = line.split(divider);
-  return '\n' + chalk.yellow(path[path.length - 1]);
+  var repoPath = config.repos
+    .sort((a, b) => a.length < b.length) // Longest repo repoPath first
+    .find(repo => line.startsWith(repo));
+  var repoRootPath = chalk.yellow(path.basename(repoPath) + divider);
+  var repoChildPath = chalk.yellow.bold(
+    line.replace(repoPath, '').replace(new RegExp(`^${divider}`), '')
+  );
+  return `\n${repoRootPath}${repoChildPath}`;
 }
 
 function llamaSay(text) {


### PR DESCRIPTION
_Loooove this app_ 😻 

This PR re-introduces longer repo names, but tries to keep them smaller than a full path by starting at the intersection between the matching configured `TTC_REPOS` var, and the found git repo.

Here is what a repo name has looked like, in chronological order:
~`/User/lok/dev/open/tiny-care-terminal`~
~`tiny-care-terminal`~
`open/tiny-care-terminal` _What this PR has settled on!_

![image](https://user-images.githubusercontent.com/1560301/32487042-34cfff00-c3f4-11e7-9360-f1ba3500b90c.png)

Feel free to drop this PR if it doesn't match up with intentions of the app. I'll continue using it on npm under `@loklaan/tiny-care-terminal`.