### PR TITLE
Use username specified in local git config

### DIFF
--- a/gitbot.js
+++ b/gitbot.js
@@ -52,12 +52,12 @@ function findGitRepos(repos, depth, callback) {
 function getCommitsFromRepos(repos, days, callback) {
   let cmts = [];
   async.each(repos, (repo, repoDone) => {
-    localGitUsername = ''
+    let localGitUsername = '';
     try {
-      gitUtilsRepo = git.open(repo);
-      localGitUsername = gitUtilsRepo.getConfigValue('user.name');
+      const gitUtilsRepo = git.open(repo);
+      localGitUsername = gitUtilsRepo.getConfigValue('user.name') || gitUsername;
     } catch (err) {
-      localGitUsername = gitUsername
+      localGitUsername = gitUsername;
     }
     try {
       gitlog({

--- a/gitbot.js
+++ b/gitbot.js
@@ -5,6 +5,7 @@ const isGit = require('is-git');
 const gitlog = require('gitlog');
 const path = require('path');
 const async = require("async");
+const git = require('git-utils');
 
 /**
  * Go through all `repos` and look for subdirectories up to a given `depth`
@@ -51,6 +52,13 @@ function findGitRepos(repos, depth, callback) {
 function getCommitsFromRepos(repos, days, callback) {
   let cmts = [];
   async.each(repos, (repo, repoDone) => {
+    localGitUsername = ''
+    try {
+      gitUtilsRepo = git.open(repo);
+      localGitUsername = gitUtilsRepo.getConfigValue('user.name');
+    } catch (err) {
+      localGitUsername = gitUsername
+    }
     try {
       gitlog({
         repo: repo,
@@ -58,7 +66,7 @@ function getCommitsFromRepos(repos, days, callback) {
         number: 100, //max commit count
         since: `${days} days ago`,
         fields: ['abbrevHash', 'subject', 'authorDateRel', 'authorName'],
-        author: gitUsername
+        author: localGitUsername
       }, (err, logs) => {
         // Error
         if (err) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "git-standup": "^2.1.8",
     "git-user-name": "^1.2.0",
     "gitlog": "^2.4.0",
+    "git-utils": "^5.2.0",
     "is-git": "0.0.1",
     "node-notifier": "^5.1.2",
     "resolve-dir": "^1.0.0",


### PR DESCRIPTION
If the user doesn't set up a global `git` user name or email, `tiny-care-terminal ` will show it all the commits in the configured repositories instead of only those committed by the user specified in the local configuration. 