### PR TITLE
show loading message while loading commits

### DIFF
--- a/care.js
+++ b/care.js
@@ -160,8 +160,7 @@ function doTheCodes() {
   var weekCommits = 0;
 
   // show loading message while loading commits
-  todayBox.content = '⏳ searching for commits...';
-  weekBox.content = '⏳ searching for commits...';
+  todayBox.content = weekBox.content = '⏳ searching for commits...';
   screen.render();
 
   function getCommits(data, box) {

--- a/care.js
+++ b/care.js
@@ -160,7 +160,7 @@ function doTheCodes() {
   var weekCommits = 0;
 
   // show loading message while loading commits
-  todayBox.content = weekBox.content = '⏳ searching for commits...';
+  todayBox.content = weekBox.content = '⏳ one second please...tiny commit bot is looking for tiny commits! ⏳';
   screen.render();
 
   function getCommits(data, box) {

--- a/care.js
+++ b/care.js
@@ -159,6 +159,11 @@ function doTheCodes() {
   var todayCommits = 0;
   var weekCommits = 0;
 
+  // show loading message while loading commits
+  todayBox.content = '⏳ searching for commits...';
+  weekBox.content = '⏳ searching for commits...';
+  screen.render();
+
   function getCommits(data, box) {
     var content = colorizeLog(data || '');
     box.content += content;


### PR DESCRIPTION
The loading of the commits can take quite some time. During startup nothing is displayed white the commits are loaded.

This PR introduces a loading message for the commit-boxes while loading the commits. This speeds up the start-up-time significantly. 🎉 