### PR TITLE
enforce npm version <= 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It looks like this, and updates every 20 minutes.
 ### 1. Do the npm dance
 
 ```
-npm install -g tiny-care-terminal
+npm install -g --engine-strict tiny-care-terminal
 ```
 (Note: this currently doesn't work with `yarn` because of path shenanigans I wrote, so while I'm fixing that, pls use `npm` 🙏)
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "main": "care.js",
   "author": "Monica Dinculescu <noms@google.com>",
   "license": "MIT",
+  "engineStrict": true,
   "engines": {
-    "node": ">=6.10.3"
+    "node": ">=6.10.3",
+    "npm": "<=5.6.0"
   },
   "bin": {
     "tiny-care-terminal": "care.js"


### PR DESCRIPTION
If tct is installed using the npm ` --engine-strict` flag an error message is presented to the user that tct is not compatible with npm versions > 5.6. It also checks for a valid node version.

fixes #131 for now.

This should be reverted after https://github.com/npm/npm/issues/20047 has been fixed.