### PR TITLE
Update README.md to remove leftover line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ lists the environment variables that you can copy in your `rc` files:
   - `TTC_REPOS_DEPTH` is the max directory-depth to look for git repositories in
   the directories defined with `TTC_REPOS` (by default 1). Note that the deeper
   the directory depth, the slower the results will be fetched.
-  seeing your commits in `tiny-terminal-care`, set this to `gitlog`
   - `TTC_WEATHER`, the location to check the weather for. A zipcode doesn't
     always work, so if you can, use a location first (so prefer `Paris` over
     `90210`)


### PR DESCRIPTION
When the README was updated to reflect the removal of the git-standup dependency, some text was left behind during editing.

This could be a bit confusing for anyone that's new to the project and hasn't yet looked through the issues and commit history.