### PR TITLE
fixes user relative repos path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ lists the environment variables that you can copy in your `rc` files:
   - `TTC_SAY_BOX = parrot | bunny | llama | cat | yeoman | mario | ironman | minions | panda`, to party with a different parrot (or,
     more specifically: to have a different animal say a message in the big box). You can create your own custom art(.ansi file) [here](https://gauravchl.github.io/ansi-art/webapp/) and download and supply it's absolute path to render it within box. (eg: `TTC_SAY_BOX='/Users/om/desktop/cat.ansi'`)
   - `TTC_REPOS`, a comma separated list of repos to look at for `git` commits.
-  If you're having trouble launching `tiny-care-terminal` and it seems to
-  crash fetching your commits, make sure the paths you're using are
-  fully qualified -- that is, use `/Users/notwaldorf/Code` rather than `~/Code`.
   - `TTC_REPOS_DEPTH` is the max directory-depth to look for git repositories in
   the directories defined with `TTC_REPOS` (by default 1). Note that the deeper
   the directory depth, the slower the results will be fetched.

--- a/config.js
+++ b/config.js
@@ -1,3 +1,14 @@
+var path = require('path');
+
+var repos = (process.env.TTC_REPOS || '~/Code');
+if( repos.indexOf('~') > -1 ){
+  var userPath = path.resolve('~');
+  var userNwPathAr = userPath.split('/');
+  userNwPathAr.pop();
+  var nwPath = userNwPathAr.join('/');
+  repos = repos.replace(/~/gmi, nwPath);
+}
+
 var config = {
   // Accounts to read the last tweet from. The first one in the list will be
   // spoken by the party parrot.
@@ -13,7 +24,7 @@ var config = {
   apiKeys: (process.env.TTC_APIKEYS || 'true') === 'true',
 
   // Directories in which to run git-standup on for a list of your recent commits.
-  repos: (process.env.TTC_REPOS || '~/Code').split(','),
+  repos: repos.split(','),
 
   // Directory-depth to look for git repositories.
   depth: (process.env.TTC_REPOS_DEPTH || 1),

--- a/config.js
+++ b/config.js
@@ -1,13 +1,4 @@
-var path = require('path');
-
-var repos = (process.env.TTC_REPOS || '~/Code');
-if( repos.indexOf('~') > -1 ){
-  var userPath = path.resolve('~');
-  var userNwPathAr = userPath.split('/');
-  userNwPathAr.pop();
-  var nwPath = userNwPathAr.join('/');
-  repos = repos.replace(/~/gmi, nwPath);
-}
+const expandHomeDir = require('expand-home-dir');
 
 var config = {
   // Accounts to read the last tweet from. The first one in the list will be
@@ -24,7 +15,7 @@ var config = {
   apiKeys: (process.env.TTC_APIKEYS || 'true') === 'true',
 
   // Directories in which to run git-standup on for a list of your recent commits.
-  repos: repos.split(','),
+  repos: (process.env.TTC_REPOS || '~/Code').split(',').map(p => expandHomeDir(p)),
 
   // Directory-depth to look for git repositories.
   depth: (process.env.TTC_REPOS_DEPTH || 1),

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "blessed": "^0.1.81",
     "blessed-contrib": "^4.7.5",
     "chalk": "^2.4.1",
+    "expand-home-dir": "^0.0.3",
     "git-user-name": "^2.0.0",
     "git-utils": "^5.4.0",
     "gitlog": "^3.1.2",


### PR DESCRIPTION
I will confirm on Windows how this works tomorrow. For now, this works on *nix and friends so far.

Since I sync my own dotfiles repo across multiple environments, which sets my tiny care terminal environment variables, I keep my pathing of git project repos the same relative  pathto my user directory, but the user directory changes between environments.

This PR seeks the `~` character, resolves it with node's `path.resolve('~')`, then replaces the occurrence in the `config.repos` value so that it can be resolved as absolute path. This has so far been tested on:

- [x] macOS 10.14 Mojave
- [x] Debian stretch, at least as in a docker container instance from the `node:latest` image, which is based on a Debian stretch image
- [x] Windows, 10