### PR TITLE
Resolve repo directories when formatting

### DIFF
--- a/care.js
+++ b/care.js
@@ -6,6 +6,7 @@ var pomodoro = require(__dirname + '/pomodoro.js');
 var ansiArt = require('ansi-art').default;
 
 var path = require('path');
+var resolve = require("resolve-dir");
 var notifier = require('node-notifier');
 var spawn = require('child_process').spawn;
 var shellescape = require('shell-escape');
@@ -271,6 +272,7 @@ function colorizeLog(text) {
 
 function formatRepoName(line, divider) {
   var repoPath = config.repos
+    .map(resolve)
     .sort((a, b) => a.length < b.length) // Longest repo repoPath first
     .find(repo => line.startsWith(repo));
   var repoRootPath = chalk.yellow(path.basename(repoPath) + divider);


### PR DESCRIPTION
Each repo directory has resolve() run on it in `gitbot.js`, (https://github.com/notwaldorf/tiny-care-terminal/blob/master/gitbot.js#L27) but does not when formatting- leading to potential non-matching.

I think there might be some case mutation going on in `resolve-dir` as I was getting exceptions in `formatRepoName` so I mapped resolve over the directory list which fixed it for me . 