### PR TITLE
refactor: remove git-utils

### DIFF
--- a/gitbot.js
+++ b/gitbot.js
@@ -4,7 +4,6 @@ const isGit = require('is-git');
 const gitlog = require('gitlog');
 const path = require('path');
 const async = require("async");
-const git = require('git-utils');
 
 try {
   const gitUsername = require('git-user-name')();
@@ -61,13 +60,7 @@ function findGitRepos(repos, depth, callback) {
 function getCommitsFromRepos(repos, days, callback) {
   let cmts = [];
   async.each(repos, (repo, repoDone) => {
-    let localGitUsername = '';
-    try {
-      const gitUtilsRepo = git.open(repo);
-      localGitUsername = gitUtilsRepo.getConfigValue('user.name') || gitUsername;
-    } catch (err) {
-      localGitUsername = gitUsername;
-    }
+    let localGitUsername = gitUsername;
     try {
       gitlog({
         repo: repo,

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,11 +79,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -98,11 +93,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -174,15 +164,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
     },
     "bresenham": {
       "version": "0.0.3",
@@ -320,11 +301,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -586,22 +562,6 @@
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
     },
-    "fs-plus": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.1.1.tgz",
-      "integrity": "sha512-Se2PJdOWXqos1qVTkvqqjb0CSnfBnwwD+pq+z4ksT+e97mEShod/hrNg0TRCCsXPbJzcIq+NuzQhigunMWMJUA==",
-      "requires": {
-        "async": "^1.5.2",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.2",
-        "underscore-plus": "1.x"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -640,15 +600,6 @@
         "parse-git-config": "^1.1.1"
       }
     },
-    "git-utils": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.6.2.tgz",
-      "integrity": "sha512-3pen//xGs5ZJiXejUbx79FyRR58J6DgI7tL9Mc7YQeuF5ENXf/7k0K2M8h4JBlTKZcxxCr8MGA1Xcg4O4l/YjA==",
-      "requires": {
-        "fs-plus": "^3.0.0",
-        "nan": "^2.14.0"
-      }
-    },
     "gitlog": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/gitlog/-/gitlog-3.1.2.tgz",
@@ -662,19 +613,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.8.1.tgz",
       "integrity": "sha512-0YCjVpE3pS5XWlN3J4X7AiAx65+nqAI54LndtVFnQZB6G/FVLkZH8y8V6R3cIoOQR4pUdfwQGd1iwyoXHJ4Qfw=="
-    },
-    "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
     },
     "global-modules": {
       "version": "1.0.0",
@@ -804,15 +742,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1034,36 +963,15 @@
         "mime-db": "1.43.0"
       }
     },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      }
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "node-chat-bubble": {
       "version": "1.0.3",
@@ -1140,14 +1048,6 @@
         "es-abstract": "^1.5.1"
       }
     },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
     "optimist": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
@@ -1176,11 +1076,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -1273,14 +1168,6 @@
       "requires": {
         "expand-tilde": "^2.0.0",
         "global-modules": "^1.0.0"
-      }
-    },
-    "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "requires": {
-        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {
@@ -1470,19 +1357,6 @@
         "request": "^2.68.0"
       }
     },
-    "underscore": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
-    },
-    "underscore-plus": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.7.0.tgz",
-      "integrity": "sha512-A3BEzkeicFLnr+U/Q3EyWwJAQPbA19mtZZ4h+lLq3ttm9kn8WC4R3YpuJZEXmWdLjYP47Zc8aLZm9kwdv+zzvA==",
-      "requires": {
-        "underscore": "^1.9.1"
-      }
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -1550,11 +1424,6 @@
         "string-width": "^2.1.1",
         "strip-ansi": "^4.0.0"
       }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "x256": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "cowsay": "^1.4.0",
     "expand-home-dir": "^0.0.3",
     "git-user-name": "^2.0.0",
-    "git-utils": "^5.6.2",
     "gitlog": "^3.1.2",
     "is-git": "^1.0.0",
     "node-notifier": "^6.0.0",


### PR DESCRIPTION
This removes some unneccessary dependencies:

```sh
├─┬ git-utils@5.6.2
│ ├─┬ fs-plus@3.1.1
│ │ ├── async@1.5.2 deduped
│ │ ├─┬ mkdirp@0.5.1
│ │ │ └── minimist@0.0.8 deduped
│ │ ├─┬ rimraf@2.7.1
│ │ │ └─┬ glob@7.1.6
│ │ │   ├── fs.realpath@1.0.0
│ │ │   ├─┬ inflight@1.0.6
│ │ │   │ ├── once@1.4.0 deduped
│ │ │   │ └── wrappy@1.0.2
│ │ │   ├── inherits@2.0.4 deduped
│ │ │   ├─┬ minimatch@3.0.4
│ │ │   │ └─┬ brace-expansion@1.1.11
│ │ │   │   ├── balanced-match@1.0.0
│ │ │   │   └── concat-map@0.0.1
│ │ │   ├─┬ once@1.4.0
│ │ │   │ └── wrappy@1.0.2 deduped
│ │ │   └── path-is-absolute@1.0.1
│ │ └─┬ underscore-plus@1.7.0
│ │   └── underscore@1.9.2
│ └── nan@2.14.0
```

This should improve the installation process, beacuse git-utils needs to compile `gitlib2` during installation what could cause problems.