### PR TITLE
Replace underpowered git-user-name by native implementation and fix error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -524,14 +524,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
-    "extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "requires": {
-        "is-extendable": "^0.1.0"
-      }
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -562,11 +554,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -583,26 +570,6 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "git-config-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-      "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "fs-exists-sync": "^0.1.0",
-        "homedir-polyfill": "^1.0.0"
-      }
-    },
-    "git-user-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/git-user-name/-/git-user-name-2.0.0.tgz",
-      "integrity": "sha512-1DC8rUNm2I5V9v4eIpK6PSjKCp9bI0t6Wl05WSk+xEMS8GhR8GWzxM3aGZfPrfuqEfWxSbui5/pQJryJFXqCzQ==",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "git-config-path": "^1.0.1",
-        "parse-git-config": "^1.1.1"
       }
     },
     "gitlog": {
@@ -773,11 +740,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -1065,17 +1027,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pad-component/-/pad-component-0.0.1.tgz",
       "integrity": "sha1-rR8izhvw/cDW3dkIrxfzUaQEuKw="
-    },
-    "parse-git-config": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
-      "integrity": "sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "fs-exists-sync": "^0.1.0",
-        "git-config-path": "^1.0.1",
-        "ini": "^1.3.4"
-      }
     },
     "parse-passwd": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "cheerio": "^1.0.0-rc.3",
     "cowsay": "^1.4.0",
     "expand-home-dir": "^0.0.3",
-    "git-user-name": "^2.0.0",
     "gitlog": "^3.1.2",
     "is-git": "^1.0.0",
     "node-notifier": "^6.0.0",


### PR DESCRIPTION
The package [`git-user-name`] merely parsed the global git configuration without evaluating any includes therein or other configuration (system, local).

This new implementation uses the git cli directly. The git cli can be assumed available since it is also used by gitlog.

Further, this implements actually working error handling. If there is an error, e.g. no git username is found or the git binary is not in `$PATH`, then the error message is shown in the daily and weekly commits sections. 
This resolves the bug that the implementation didn't throw an error if there was no username. Also, even if an error was thrown by the library, the error message was not printed where the user could see it, but the application merely exited (which is mentioned as an anti-pattern in nodejs' [process documentation]).

[`git-user-name`]: https://github.com/jonschlinkert/git-user-name/blob/22cf1d3880356c754f7d84dec242987a3b8fcc7e/index.js
[process documentation]: https://nodejs.org/api/process.html#process_process_exit_code