### PR TITLE
Filter commits module

### DIFF
--- a/filter-commits.js
+++ b/filter-commits.js
@@ -1,0 +1,23 @@
+// filter-commits.js
+const ignorableCommits = [
+    'Apply fixes from StyleCI'
+];
+
+function filterCommit(message) {
+    if (message === '') {
+        return false;
+    }
+
+    return contains(message);
+}
+
+function contains(message) {
+    let value = 0;
+    ignorableCommits.forEach(function(commit){
+        value = value + message.includes(commit);
+    });
+
+    return value == 0;
+}
+
+module.exports.hasNotAllowedMessage = filterCommit;

--- a/gitbot.js
+++ b/gitbot.js
@@ -4,6 +4,7 @@ const isGit = require('is-git');
 const gitlog = require('gitlog');
 const async = require("async");
 const { exec } = require("child_process");
+const commitFilter = require('./filter-commits');
 
 function craftGetGitUserErrorMessage(error, stdout) {
   return `ERROR reading git-config.
@@ -95,9 +96,11 @@ async function getCommitsFromRepos(repos, days, callback) {
         // Find user commits
         let commits = [];
         logs.forEach(c => {
-          // filter simple merge commits
-          if (c.status && c.status.length)
-            commits.push(`${c.abbrevHash} - ${c.subject} (${c.authorDateRel}) <${c.authorName.replace('@end@\n','')}>`);
+          if (commitFilter.hasNotAllowedMessage(c.subject) !== false) {
+            // filter simple merge commits
+            if (c.status && c.status.length)
+              commits.push(`${c.abbrevHash} - ${c.subject} (${c.authorDateRel}) <${c.authorName.replace('@end@\n','')}>`);
+          }
         });
 
         // Add repo name and commits


### PR DESCRIPTION
As we are using this plugin to get a quick view on how much we are commiting, (and also we are using StyleCI) would be nice to ignore somehow the auto-commits made from some code review tools...

_PS: I can refactor this to make it more smart but I don't have/know any other tools that makes fix + autocommit (and what commit messages) like StyleCI does._

Thanks!